### PR TITLE
Infinity/-infinity datetime

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -1,6 +1,7 @@
 Changes
 ignore.txt
 lib/PGObject/Type/DateTime.pm
+lib/PGObject/Type/DateTime/Infinite.pm
 LICENSE
 Makefile.PL
 MANIFEST

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -18,7 +18,7 @@ WriteMakefile(
 	'DateTime::TimeZone' => 0,
     },
     BUILD_REQUIRES => {
-        'Test::More' => 0,
+        'Test2::V0' => 0,
     },
     dist                => { COMPRESS => 'gzip -9f', SUFFIX => 'gz', },
     clean               => { FILES => 'PGObject-Type-DateTime-*' },

--- a/lib/PGObject/Type/DateTime.pm
+++ b/lib/PGObject/Type/DateTime.pm
@@ -6,6 +6,7 @@ use strict;
 use warnings;
 use base qw(DateTime);
 use DateTime::TimeZone;
+use PGObject::Type::DateTime::Infinite;
 use PGObject;
 
 =head1 NAME
@@ -14,11 +15,11 @@ PGObject::Type::DateTime - DateTime Wrappers for PGObject
 
 =head1 VERSION
 
-Version 2.0.2
+Version 2.1.0
 
 =cut
 
-our $VERSION = 2.000002;
+our $VERSION = '2.1.0';
 our $default_tz = DateTime::TimeZone->new(name => 'UTC');
 
 
@@ -124,6 +125,24 @@ sub today {
     return $self;
 }
 
+=head2 inf_future
+
+Returns a timestamp infinitely far in the future.  This wraps
+C<DateTime::Infinite::Future>.
+
+=cut
+
+sub inf_future { PGObject::Type::DateTime::Infinite::Future->new }
+
+=head2 inf_past
+
+Returns a timestamp infinitely far in the past.  This wraps
+C<DateTime::Infinite::Past>
+
+=cut
+
+sub inf_past { PGObject::Type::DateTime::Infinite::Past->new }
+
 =head2 last_day_of_month
 
 Wraps C<DateTime::last_day_of_month>, clearing the internal flag which
@@ -179,6 +198,8 @@ sub from_db {
     my ($class, $value) = @_;
     my ($year, $month, $day, $hour, $min, $sec, $nanosec, $tz);
     $value = '' if not defined $value;
+    return inf_future if $value =~ /^\+?infinity$/;
+    return inf_past if $value eq '-infinity';
     $value =~ /(\d{4})-(\d{2})-(\d{2})/ 
           and ($year, $month, $day) = ($1, $2, $3);
     $value =~ /(\d+):(\d+):([0-9.]+)([+-]\d{1,4})?/ 

--- a/lib/PGObject/Type/DateTime/Infinite.pm
+++ b/lib/PGObject/Type/DateTime/Infinite.pm
@@ -1,0 +1,95 @@
+=head1 NAME
+
+   PGObject::Util::Type::DateTime::Infinite -- Infinite Date Times in PGObject
+
+=head1 VERSION
+
+   2.1.0
+
+=head1 SYNOPSIS
+
+   # for a timestamp infinitely far in the future
+   my $future = PGObject::Util::Type::DateTime::Infinite::Future->new
+
+   # or infinitely far in the past
+
+   my $past = PGObject::Util::Type::DateTime::Infinite::Past->new
+
+=cut
+
+# This package doesn't do anything, just there for loading
+# and to make sure other modules are loaded since the modules
+# we subclass are found in DateTime::Infinite's perl module
+
+package PGObject::Util::Type::DateTime::Infinite;
+use DateTime::Infinite; # loads the classes we will be using.
+use strict;
+use warnings;
+
+=head1 DESCRIPTION
+
+PostgreSQL supports timestamps of 'infinity' (can also be written '+infinity')
+and '-infinity' and it turns out Perl has support for the same.  So this module
+implements a bridge between PGObject and this functionality.
+
+=head1 SUBCLASSES
+
+This module offers two subclasses for future and past.
+
+=head2 PGObject::Util::Type::DateTime::Infinite::Future
+
+This class +infinity and infinity to DateTime::Infinite::Future objects
+
+=head2 PGObject::Util::Type::DateTime::Infinite::Past
+
+This class maps -infinity to DateTime::Infinite::Past objects.
+
+=cut
+
+package PGObject::Type::DateTime::Infinite::Future;
+use parent -norequire, qw(DateTime::Infinite::Future PGObject::Type::DateTime);
+use strict;
+use warnings;
+
+sub new {
+    my $class = shift;
+    my $val = DateTime::Infinite::Future->new;
+    bless $val, ($class // __PACKAGE__);
+}
+
+sub to_db { 'infinity' }
+
+package PGObject::Type::DateTime::Infinite::Past;
+use parent -norequire, qw(DateTime::Infinite::Past PGObject::Type::DateTime);
+use strict;
+use warnings;
+
+sub new {
+    my $class = shift;
+    my $val = DateTime::Infinite::Past->new;
+    bless $val, ($class // __PACKAGE__);
+}
+
+sub to_db { '-infinity' }
+
+=head1 SEE ALSO
+
+=over
+
+=item DateTime::Infinite
+
+=item DateTime
+
+=item PGObject::Type::DateTime
+
+=back
+
+=head1 COPYING
+
+See the terms of PGObject::Type::DateTime for the license agreement as this
+is part of that package.
+
+=cut
+
+1;
+

--- a/t/00-load.t
+++ b/t/00-load.t
@@ -1,9 +1,12 @@
 #!perl -T
 
-use Test::More tests => 1;
+use Test2::V0;
+
+plan 2;
 
 BEGIN {
-    use_ok( 'PGObject::Type::DateTime' ) || print "Bail out!\n";
+    ok ( eval 'require PGObject::Type::DateTime' ) || print "Bail out!\n";
+    ok ( eval 'require PGObject::Type::DateTime::Infinite' ) || print "Bail out!\n";
 }
 
 diag( "Testing PGObject::Type::DateTime $PGObject::Type::DateTime::VERSION, Perl $], $^X" );

--- a/t/01-constructor.t
+++ b/t/01-constructor.t
@@ -1,45 +1,47 @@
 use PGObject::Type::DateTime;
-use Test::More tests => 26;
+use Test2::V0;
+
+plan 26;
+
 
 my $test;
 
 $test = PGObject::Type::DateTime->from_db("2013-12-11 11:11:11.11234-08");
-isa_ok $test, 'DateTime', 'long parse, isa date time';
-isa_ok $test, 'PGObject::Type::DateTime', 'long parse, is expected class';
+isa_ok $test, ['DateTime'], 'long parse, isa date time';
+isa_ok $test, ['PGObject::Type::DateTime'], 'long parse, is expected class';
 is $test->to_db, "2013-12-11 11:11:11.11234-08", 'long parse, expected db out';
 ok $test->is_tz, 'long parse, timezone';
 
 $test = PGObject::Type::DateTime->from_db('2012-12-11'); 
-isa_ok $test, 'DateTime', 'date only, isa date time';
-isa_ok $test, 'PGObject::Type::DateTime', 'date only, is expected class';
+isa_ok $test, ['DateTime'], 'date only, isa date time';
+isa_ok $test, ['PGObject::Type::DateTime'], 'date only, is expected class';
 is $test->to_db, "2012-12-11", 'date only, expected db out';
 is $test->is_tz, 0, 'date only, no timezone';
 
 $test = PGObject::Type::DateTime->from_db('11:11:23.1111');
-isa_ok $test, 'DateTime', 'time only, isa date time';
-isa_ok $test, 'PGObject::Type::DateTime', 'time only, is expected class';
+isa_ok $test, ['DateTime'], 'time only, isa date time';
+isa_ok $test, ['PGObject::Type::DateTime'], 'time only, is expected class';
 is $test->to_db, "11:11:23.1111", 'long parse, expected db out';
 is $test->is_tz, 0, 'time only, no timezone';
 
 $test = PGObject::Type::DateTime->from_db("2013-12-11 00:00:00.0000-08");
-isa_ok $test, 'DateTime', 'Midnight, isa date time';
-isa_ok $test, 'PGObject::Type::DateTime', 'Midnight. is expected class';
+isa_ok $test, ['DateTime'], 'Midnight, isa date time';
+isa_ok $test, ['PGObject::Type::DateTime'], 'Midnight. is expected class';
 is $test->to_db, "2013-12-11 00:00:00.0-08", 'Midnight, expected db out';
 ok $test->is_tz, 'Midnight, timezone';
 
 $test = PGObject::Type::DateTime->from_db("2013-12-11 00:00:00.0000");
-isa_ok $test, 'DateTime', 'Midnight, no time zone, isa date time';
-isa_ok $test, 'PGObject::Type::DateTime', 'Midnight. is expected class';
+isa_ok $test, ['DateTime'], 'Midnight, no time zone, isa date time';
+isa_ok $test, ['PGObject::Type::DateTime'], 'Midnight. is expected class';
 is $test->to_db, "2013-12-11 00:00:00.0", 'Midnight, expected db out';
 is $test->is_tz, 0, 'Midnight, timezone';
 
 $test = PGObject::Type::DateTime->from_db("2013-12-11 00:00:00.0000+08");
-isa_ok $test, 'DateTime', 'Midnight, positive offset, isa date time';
-isa_ok $test, 'PGObject::Type::DateTime', 'Midnight positive offset. is expected class';
+isa_ok $test, ['DateTime'], 'Midnight, positive offset, isa date time';
+isa_ok $test, ['PGObject::Type::DateTime'], 'Midnight positive offset. is expected class';
 is $test->to_db, "2013-12-11 00:00:00.0+08", 'Midnight positive offset, expected db out';
 ok $test->is_tz, 'Midnight, positive offset, timezone';
 
 $test =  PGObject::Type::DateTime->from_db(undef);
-isa_ok $test, 'DateTime', 'undef';
+isa_ok $test, ['DateTime'], 'undef';
 is $test->to_db, undef;
-

--- a/t/02-registration.t
+++ b/t/02-registration.t
@@ -1,5 +1,7 @@
 
-use Test::More tests => 15;
+use Test2::V0;
+
+plan 15;
 
 use PGObject;
 use PGObject::Type::DateTime;
@@ -18,7 +20,7 @@ diag Dumper(\%{"::PGObject::Type::"});
 # 4.  Registration with custom registry 'test', default types
 # 5.  Registry properly lists all appropriate types.
 
-ok(PGObject->new_registry('test'), 'creating test registry');
+ok(PGObject::Type::Registry->new_registry('test'), 'creating test registry');
 
 ok(PGObject::Type::DateTime->register(), 'default registration');
 ok(PGObject::Type::DateTime->register(types => ['mytime']), 'mytime registration');

--- a/t/03-dbtests.t
+++ b/t/03-dbtests.t
@@ -1,4 +1,4 @@
-use Test::More;
+use Test2::V0;
 use DBI;
 use PGObject;
 use PGObject::Type::DateTime;
@@ -54,7 +54,7 @@ for my $fnc (keys %$functions){
 # Planning
 
 if ($dbh) {
-   plan tests => 15;
+   plan 15;
 } else {
    plan skipall => "No database connection, or connection failed";
 }

--- a/t/03-dbtests.t
+++ b/t/03-dbtests.t
@@ -26,6 +26,14 @@ my $functions = {
                create or replace function test__roundtrip(date) returns date
                language sql as
                $$SELECT $1;$$',
+     infinity  => q|
+               create or replace function test__infinity() returns timestamp
+               language sql as
+               $$ select 'infinity'::timestamp; $$|,
+     infpast   => q|
+               create or replace function test__infpast() returns timestamp
+               language sql as
+               $$ select '-infinity'::timestamp; $$|,
                
 };
 
@@ -46,14 +54,14 @@ for my $fnc (keys %$functions){
 # Planning
 
 if ($dbh) {
-   plan tests => 11;
+   plan tests => 15;
 } else {
    plan skipall => "No database connection, or connection failed";
 }
 
 # Test cases
 
-for my $type (qw(date time timestamp timestamptz)){
+for my $type (qw(date time timestamp timestamptz infinity infpast)){
     my ($ref) = PGObject->call_procedure(
            funcname   => $type,
            funcprefix => 'test__',

--- a/t/04-overloaded.t
+++ b/t/04-overloaded.t
@@ -1,50 +1,64 @@
 #!perl
 
 use PGObject::Type::DateTime;
-use Test::More tests => 41;
+use Test2::V0;
+plan 49;
 
 my $test;
 
 $test = PGObject::Type::DateTime->today;
-isa_ok $test, 'DateTime', 'overloaded today(), isa date time';
-isa_ok $test, 'PGObject::Type::DateTime', 'overloaded today(), is expected class';
+isa_ok $test, ['DateTime'], 'overloaded today(), isa date time';
+isa_ok $test, ['PGObject::Type::DateTime'], 'overloaded today(), is expected class';
 like $test->to_db, qr/^\d{4}-\d{2}-\d{2}$/, 'overloaded today() returns a date only';
 
 for my $trunc (qw/ year month week local_week day/) {
     $test = PGObject::Type::DateTime->now->truncate( to => $trunc );
-    isa_ok $test, 'DateTime', 'truncate (no time), isa date time';
-    isa_ok $test, 'PGObject::Type::DateTime', 'truncate (no time), is expected class';
+    isa_ok $test, ['DateTime'], 'truncate (no time), isa date time';
+    isa_ok $test, ['PGObject::Type::DateTime'], 'truncate (no time), is expected class';
     ok(! $test->is_time, 'truncate (no time), has no time');
 }
 
 for my $trunc (qw/ hour minute second /) {
     $test = PGObject::Type::DateTime->now->truncate( to => $trunc );
-    isa_ok $test, 'DateTime', 'truncate (with time), isa date time';
-    isa_ok $test, 'PGObject::Type::DateTime', 'truncate (with time), is expected class';
+    isa_ok $test, ['DateTime'], 'truncate (with time), isa date time';
+    isa_ok $test, ['PGObject::Type::DateTime'], 'truncate (with time), is expected class';
     ok($test->is_time, 'truncate (with time), has time');
 }
 
 
 $test = PGObject::Type::DateTime->last_day_of_month(year => 2015, month => 12);
-isa_ok $test, 'DateTime', 'last_day_of_month, isa date time';
-isa_ok $test, 'PGObject::Type::DateTime', 'last_day_of_month, is expected class';
+isa_ok $test, ['DateTime'], 'last_day_of_month, isa date time';
+isa_ok $test, ['PGObject::Type::DateTime'], 'last_day_of_month, is expected class';
 ok ! $test->is_time, 'last_day_of_month has no time';
 
 
 $test = PGObject::Type::DateTime->from_day_of_year(year => 2015,
                                                    day_of_year => 150);
-isa_ok $test, 'DateTime', 'from_day_of_year, isa date time';
-isa_ok $test, 'PGObject::Type::DateTime', 'from_day_of_year, is expected class';
+isa_ok $test, ['DateTime'], 'from_day_of_year, isa date time';
+isa_ok $test, ['PGObject::Type::DateTime'], 'from_day_of_year, is expected class';
 ok ! $test->is_time, 'from_day_of_year has no time';
 
 $test = PGObject::Type::DateTime->inf_future;
-isa_ok $test, 'DateTime', 'Infinite future datetime is DateTime';
-isa_ok $test, 'DateTime::Infinite::Future', 'Infinite future datetime is DateTime::Infinite::Future';
-isa_ok $test, 'PGObject::Type::DateTime', 'Infinite future datetime is PGObject::Type::DateTime';
+isa_ok $test, ['DateTime'], 'Infinite future datetime is DateTime';
+isa_ok $test, ['DateTime::Infinite::Future'], 'Infinite future datetime is DateTime::Infinite::Future';
+isa_ok $test, ['PGObject::Type::DateTime'], 'Infinite future datetime is PGObject::Type::DateTime';
 is $test->to_db, 'infinity', "Infinite future datetime serializes to db as 'infinity'";
 
 $test = PGObject::Type::DateTime->inf_past;
-isa_ok $test, 'DateTime', 'Infinite past datetime is DateTime';
-isa_ok $test, 'DateTime::Infinite::Past', 'Infinite past datetime is DateTime::Infinite::Past';
-isa_ok $test, 'PGObject::Type::DateTime', 'Infinite past datetime is PGObject::Type::DateTime';
-is $test->to_db, 'infinity', "Infinite past datetime serializes to db as '-infinity'";
+isa_ok $test, ['DateTime'], 'Infinite past datetime is DateTime';
+isa_ok $test, ['DateTime::Infinite::Past'], 'Infinite past datetime is DateTime::Infinite::Past';
+isa_ok $test, ['PGObject::Type::DateTime'], 'Infinite past datetime is PGObject::Type::DateTime';
+is $test->to_db, '-infinity', "Infinite past datetime serializes to db as '-infinity'";
+
+$test = PGObject::Type::DateTime->from_db('infinity');
+isa_ok $test, ['DateTime'], 'Infinity is datetime';
+isa_ok $test, ['PGObject::Type::DateTime'], 'Infinity is expected class';
+isa_ok $test, ['DateTime::Infinite::Future'], 'Infinity is expected infinite class';
+is $test->to_db, 'infinity', 'Infinity serializes to db as infinity';
+
+$test =  PGObject::Type::DateTime->from_db('-infinity');
+isa_ok $test, ['DateTime'], '-Infinity is datetime';
+isa_ok $test, ['PGObject::Type::DateTime'], '-Infinity is expected class';
+isa_ok $test, ['DateTime::Infinite::Past'], '-Infinity is expected infinite class';
+is $test->to_db, '-infinity', '-Infinity serializes to db as -infinity';
+

--- a/t/04-overloaded.t
+++ b/t/04-overloaded.t
@@ -1,7 +1,7 @@
 #!perl
 
 use PGObject::Type::DateTime;
-use Test::More tests => 33;
+use Test::More tests => 41;
 
 my $test;
 
@@ -37,3 +37,14 @@ isa_ok $test, 'DateTime', 'from_day_of_year, isa date time';
 isa_ok $test, 'PGObject::Type::DateTime', 'from_day_of_year, is expected class';
 ok ! $test->is_time, 'from_day_of_year has no time';
 
+$test = PGObject::Type::DateTime->inf_future;
+isa_ok $test, 'DateTime', 'Infinite future datetime is DateTime';
+isa_ok $test, 'DateTime::Infinite::Future', 'Infinite future datetime is DateTime::Infinite::Future';
+isa_ok $test, 'PGObject::Type::DateTime', 'Infinite future datetime is PGObject::Type::DateTime';
+is $test->to_db, 'infinity', "Infinite future datetime serializes to db as 'infinity'";
+
+$test = PGObject::Type::DateTime->inf_past;
+isa_ok $test, 'DateTime', 'Infinite past datetime is DateTime';
+isa_ok $test, 'DateTime::Infinite::Past', 'Infinite past datetime is DateTime::Infinite::Past';
+isa_ok $test, 'PGObject::Type::DateTime', 'Infinite past datetime is PGObject::Type::DateTime';
+is $test->to_db, 'infinity', "Infinite past datetime serializes to db as '-infinity'";

--- a/t/boilerplate.t
+++ b/t/boilerplate.t
@@ -3,7 +3,8 @@
 use 5.006;
 use strict;
 use warnings;
-use Test::More tests => 3;
+use Test2::V0;
+plan 3;
 
 sub not_in_file_ok {
     my ($filename, %regex) = @_;

--- a/t/manifest.t
+++ b/t/manifest.t
@@ -2,7 +2,7 @@
 
 use strict;
 use warnings;
-use Test::More;
+use Test2::V0;
 
 unless ( $ENV{RELEASE_TESTING} ) {
     plan( skip_all => "Author tests not required for installation" );

--- a/t/pod-coverage.t
+++ b/t/pod-coverage.t
@@ -1,6 +1,6 @@
 use strict;
 use warnings;
-use Test::More;
+use Test2::V0;
 
 # Ensure a recent version of Test::Pod::Coverage
 my $min_tpc = 1.08;

--- a/t/pod.t
+++ b/t/pod.t
@@ -2,7 +2,7 @@
 
 use strict;
 use warnings;
-use Test::More;
+use Test2::V0;
 
 # Ensure a recent version of Test::Pod
 my $min_tp = 1.22;


### PR DESCRIPTION
This PR has two commits.

The first commit adds support for infinite DateTime types.  DateTime supports these natively so this doesn't break anything.

These map to infinity and -infinity PostgreSQL timestamp values.

The second commit modernizes the test cases to use Test2::V0.

